### PR TITLE
fix: parse whole line of comment

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -104,6 +104,7 @@ module.exports = grammar({
 
         line_comment: $ => token(seq(
             '#',
+            /.*/,
         )),
 
         // How lines can end

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -38,6 +38,10 @@
           {
             "type": "STRING",
             "value": "#"
+          },
+          {
+            "type": "PATTERN",
+            "value": ".*"
           }
         ]
       }

--- a/src/parser.c
+++ b/src/parser.c
@@ -4847,6 +4847,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 94:
       ACCEPT_TOKEN(sym_line_comment);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(94);
       END_STATE();
     case 95:
       ACCEPT_TOKEN(anon_sym_PIPE);

--- a/test/corpus/line_comment.txt
+++ b/test/corpus/line_comment.txt
@@ -1,0 +1,10 @@
+==================
+line comment
+==================
+
+# comment
+
+---
+
+(source_file
+    (line_comment))


### PR DESCRIPTION
The grammar was only capturing the hashtag that initiates the comment, but not the rest of the line.